### PR TITLE
feat: add Operator Console workflow

### DIFF
--- a/api/server/admin_routes.py
+++ b/api/server/admin_routes.py
@@ -20,7 +20,7 @@ Adds the following endpoints consumed by the admin dashboard:
 
 from __future__ import annotations
 
-import fcntl
+from filelock import FileLock
 import json
 import logging
 import os
@@ -332,16 +332,14 @@ def register_admin_routes(app: FastAPI) -> None:
     }
 
     def _locked_jsonl_append(path: Path, data: Dict[str, Any]) -> None:
-        """Append one JSON line with exclusive file locking."""
+        """Append one JSON line with cross-platform file locking."""
         path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(data, ensure_ascii=False) + "\n"
-        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
-            os.write(fd, line.encode("utf-8"))
-        finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-            os.close(fd)
+        lock_path = str(path) + ".lock"
+        lock = FileLock(lock_path)
+        with lock:
+            with open(path, "a", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False)
+                f.write("\n")
 
     @app.post(
         "/api/dashboard/eval-cases",
@@ -512,3 +510,266 @@ def register_admin_routes(app: FastAPI) -> None:
             current["updated_by"],
         )
         return {"status": "ok", "config": current}
+
+    # ---- Operator Console (Issue #34) ------------------------------------
+
+    _RAW_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "raw"
+    _MODELS_DIR = Path(__file__).resolve().parent.parent.parent / "models"
+
+    @app.get("/admin/operator", include_in_schema=False)
+    async def operator_page() -> HTMLResponse:
+        """Operator Console HTML page."""
+        html_path = _STATIC_DIR / "operator.html"
+        if not html_path.exists():
+            raise HTTPException(status_code=404, detail="Operator Console not found")
+        return HTMLResponse(content=html_path.read_text(encoding="utf-8"))
+
+    @app.post("/admin/ask", dependencies=[Depends(verify_admin_token)])
+    async def operator_ask(request: Request) -> Dict[str, Any]:
+        """Ask the RAG system a question (Operator Console)."""
+        body = await request.json()
+        question = (body.get("question") or body.get("query") or "").strip()
+        if not question:
+            raise HTTPException(status_code=422, detail="question is required")
+
+        rag_service = getattr(request.app.state, "rag_service", None)
+        if rag_service is None or not rag_service.ready:
+            raise HTTPException(status_code=503, detail="RAG pipeline not ready")
+
+        t0 = time.perf_counter()
+        result = await rag_service.query(question)
+        wall_ms = int((time.perf_counter() - t0) * 1000)
+
+        return {
+            "status": "ok",
+            "query": question,
+            "answer": result.get("answer", ""),
+            "sources": result.get("sources", []),
+            "intent": result.get("intent", "general"),
+            "intent_confidence": result.get("intent_confidence", 0.0),
+            "grounded": result.get("grounded", False),
+            "failure_type": result.get("failure_type"),
+            "latency_ms": wall_ms,
+            "request_id": result.get("request_id", ""),
+        }
+
+    @app.get("/admin/knowledge", dependencies=[Depends(verify_admin_token)])
+    async def list_knowledge_files() -> Dict[str, Any]:
+        """List all knowledge files in data/raw."""
+        _RAW_DIR.mkdir(parents=True, exist_ok=True)
+        files = []
+        for path in sorted(_RAW_DIR.rglob("*")):
+            if path.is_file() and path.suffix.lower() in {".txt", ".md"}:
+                rel_path = path.relative_to(_RAW_DIR)
+                files.append({
+                    "name": str(rel_path).replace("\\", "/"),
+                    "size": path.stat().st_size,
+                    "modified": path.stat().st_mtime,
+                })
+        return {"files": files, "total": len(files)}
+
+    @app.get("/admin/knowledge/{filename:path}", dependencies=[Depends(verify_admin_token)])
+    async def get_knowledge_file(filename: str) -> Dict[str, Any]:
+        """Read a knowledge file."""
+        # Prevent path traversal
+        safe_name = filename.replace("..", "").replace("//", "/").lstrip("/")
+        if not safe_name:
+            raise HTTPException(status_code=400, detail="Invalid filename")
+
+        file_path = _RAW_DIR / safe_name
+        try:
+            file_path.relative_to(_RAW_DIR)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid path")
+
+        if not file_path.exists() or not file_path.is_file():
+            raise HTTPException(status_code=404, detail="File not found")
+
+        suffix = file_path.suffix.lower()
+        if suffix not in {".txt", ".md"}:
+            raise HTTPException(status_code=400, detail="Only .txt and .md files allowed")
+
+        content = file_path.read_text(encoding="utf-8", errors="ignore")
+        return {
+            "filename": safe_name,
+            "content": content,
+            "size": len(content),
+            "modified": file_path.stat().st_mtime,
+        }
+
+    @app.post("/admin/knowledge/{filename:path}", dependencies=[Depends(verify_admin_token)])
+    async def save_knowledge_file(filename: str, request: Request) -> Dict[str, Any]:
+        """Save a knowledge file."""
+        body = await request.json()
+        content = body.get("content", "")
+
+        # Prevent path traversal
+        safe_name = filename.replace("..", "").replace("//", "/").lstrip("/")
+        if not safe_name:
+            raise HTTPException(status_code=400, detail="Invalid filename")
+
+        file_path = _RAW_DIR / safe_name
+        try:
+            file_path.relative_to(_RAW_DIR)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid path")
+
+        suffix = file_path.suffix.lower()
+        if suffix not in {".txt", ".md"}:
+            raise HTTPException(status_code=400, detail="Only .txt and .md files allowed")
+
+        # Ensure parent directory exists
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        file_path.write_text(content, encoding="utf-8")
+        return {
+            "status": "ok",
+            "filename": safe_name,
+            "size": len(content),
+            "saved_at": time.time(),
+        }
+
+    @app.post("/admin/rebuild", dependencies=[Depends(verify_admin_token)])
+    async def rebuild_indexes(request: Request) -> Dict[str, Any]:
+        """Trigger knowledge base rebuild."""
+        import subprocess
+        import sys
+
+        try:
+            # Run build_indexes.py script
+            result = subprocess.run(
+                [sys.executable, "scripts/build_indexes.py"],
+                cwd=Path(__file__).resolve().parent.parent.parent,
+                capture_output=True,
+                text=True,
+                timeout=300,  # 5 minute timeout
+            )
+
+            success = result.returncode == 0
+            output = result.stdout if success else result.stderr
+
+            # Get index counts
+            rag_service = getattr(request.app.state, "rag_service", None)
+            index_count = 0
+            if rag_service and rag_service.ready:
+                index_count = rag_service.index_count
+
+            return {
+                "status": "ok" if success else "error",
+                "success": success,
+                "returncode": result.returncode,
+                "output": output[-2000:] if output else "",  # Last 2000 chars
+                "index_count": index_count,
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "status": "error",
+                "success": False,
+                "error": "Rebuild timed out after 5 minutes",
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "success": False,
+                "error": str(e),
+            }
+
+    @app.post("/admin/eval", dependencies=[Depends(verify_admin_token)])
+    async def run_eval() -> Dict[str, Any]:
+        """Run evaluation tests."""
+        import subprocess
+        import sys
+
+        eval_script = Path(__file__).resolve().parent.parent.parent / "scripts" / "run_eval.py"
+
+        if not eval_script.exists():
+            return {
+                "status": "not_configured",
+                "configured": False,
+                "message": "Eval runner not found at scripts/run_eval.py",
+            }
+
+        try:
+            result = subprocess.run(
+                [sys.executable, str(eval_script)],
+                cwd=Path(__file__).resolve().parent.parent.parent,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+
+            # Try to parse pass/fail from output
+            output = result.stdout + result.stderr
+            passed = result.returncode == 0
+
+            return {
+                "status": "ok" if passed else "failed",
+                "configured": True,
+                "passed": passed,
+                "returncode": result.returncode,
+                "output": output[-2000:] if output else "",
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "status": "timeout",
+                "configured": True,
+                "passed": False,
+                "error": "Eval timed out",
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "configured": True,
+                "passed": False,
+                "error": str(e),
+            }
+
+    @app.get("/admin/status", dependencies=[Depends(verify_admin_token)])
+    async def get_publish_status(request: Request) -> Dict[str, Any]:
+        """Get publish/readiness status."""
+        rag_service = getattr(request.app.state, "rag_service", None)
+
+        rag_ready = False
+        index_count = 0
+        if rag_service:
+            rag_ready = rag_service.ready
+            index_count = rag_service.index_count
+
+        # Check for indexes
+        models_exist = _MODELS_DIR.exists() and any(_MODELS_DIR.iterdir())
+
+        # Load last build info if available
+        build_info = {"last_build": None, "last_error": None}
+        build_status_file = _EVAL_DIR / "last_build.json"
+        if build_status_file.exists():
+            try:
+                build_info = json.loads(build_status_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # Load last eval info if available
+        eval_info = {"last_eval_pass_rate": None, "last_eval_time": None}
+        eval_status_file = _EVAL_DIR / "last_eval.json"
+        if eval_status_file.exists():
+            try:
+                eval_info = json.loads(eval_status_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        config = _load_rag_config()
+
+        # Determine readiness
+        ready = rag_ready and models_exist and index_count > 0
+
+        return {
+            "status": "ready" if ready else "not_ready",
+            "ready": ready,
+            "config_version": config.get("version", 1),
+            "index_count": index_count,
+            "models_exist": models_exist,
+            "rag_ready": rag_ready,
+            "last_build": build_info.get("last_build"),
+            "last_build_error": build_info.get("last_error"),
+            "last_eval_pass_rate": eval_info.get("last_eval_pass_rate"),
+            "last_eval_time": eval_info.get("last_eval_time"),
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ python-docx>=1.1.0
 fastapi>=0.115.0
 uvicorn>=0.30.0
 python-multipart>=0.0.6
+httpx>=0.27.0
+filelock>=3.13.0
+httpx>=0.27.0

--- a/static/admin.html
+++ b/static/admin.html
@@ -164,7 +164,10 @@ background:var(--green);color:#fff;font-size:.85rem;cursor:pointer}
 <div id="app" style="display:none">
 <header>
   <h1>RAG Control Center</h1>
-  <span class="logout" onclick="doLogout()">Sign out</span>
+  <div style="display:flex;gap:1rem;align-items:center">
+    <a href="/admin/operator" style="font-size:.85rem">← Operator Console</a>
+    <span class="logout" onclick="doLogout()">Sign out</span>
+  </div>
 </header>
 
 <div class="container">

--- a/static/operator.html
+++ b/static/operator.html
@@ -1,0 +1,599 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Operator Console — RAG Intent System</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--bg:#0f1117;--card:#1a1d27;--border:#2a2d3a;--text:#e0e0e6;--muted:#8b8fa3;
+--accent:#6c63ff;--green:#22c55e;--yellow:#eab308;--red:#ef4444;--blue:#3b82f6;
+--orange:#f97316}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+background:var(--bg);color:var(--text);line-height:1.5}
+a{color:var(--accent);text-decoration:none}
+
+/* ---------- Login overlay ---------- */
+#login-overlay{position:fixed;inset:0;background:var(--bg);display:flex;
+align-items:center;justify-content:center;z-index:100}
+#login-box{background:var(--card);padding:2rem;border-radius:.75rem;
+border:1px solid var(--border);width:360px;text-align:center}
+#login-box h2{margin-bottom:1rem;font-size:1.25rem}
+#login-box input{width:100%;padding:.6rem .8rem;border-radius:.5rem;
+border:1px solid var(--border);background:var(--bg);color:var(--text);
+font-size:.95rem;margin-bottom:.75rem}
+#login-box button{width:100%;padding:.6rem;border:none;border-radius:.5rem;
+background:var(--accent);color:#fff;font-size:.95rem;cursor:pointer}
+#login-box button:hover{opacity:.9}
+#login-error{color:var(--red);font-size:.85rem;min-height:1.2em;margin-bottom:.5rem}
+
+/* ---------- Layout ---------- */
+header{padding:1rem 1.5rem;border-bottom:1px solid var(--border);
+display:flex;align-items:center;justify-content:space-between}
+header h1{font-size:1.2rem;font-weight:600}
+header .logout{font-size:.85rem;cursor:pointer;color:var(--muted)}
+header .logout:hover{color:var(--text)}
+.container{max-width:1200px;margin:0 auto;padding:1.5rem}
+
+/* ---------- Cards ---------- */
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;margin-bottom:1.5rem}
+.card{background:var(--card);border:1px solid var(--border);border-radius:.75rem;padding:1.25rem}
+.card .label{font-size:.8rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em}
+.card .value{font-size:1.8rem;font-weight:700;margin-top:.25rem}
+.card .value.ok{color:var(--green)}.card .value.warn{color:var(--yellow)}.card .value.bad{color:var(--red)}
+
+/* ---------- Sections ---------- */
+.section{background:var(--card);border:1px solid var(--border);border-radius:.75rem;
+padding:1.25rem;margin-bottom:1.5rem}
+.section h2{font-size:1rem;font-weight:600;margin-bottom:1rem;display:flex;align-items:center;gap:.5rem}
+.section h2 .icon{font-size:1.1rem}
+
+/* ---------- Forms ---------- */
+.form-group{margin-bottom:1rem}
+.form-group label{display:block;font-size:.85rem;color:var(--muted);margin-bottom:.35rem}
+.form-group input,.form-group textarea{width:100%;padding:.6rem .8rem;border-radius:.5rem;
+border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:.9rem}
+.form-group textarea{min-height:120px;resize:vertical;font-family:'Fira Code',monospace;font-size:.85rem}
+.form-row{display:flex;gap:1rem;flex-wrap:wrap}
+.form-row .form-group{flex:1;min-width:200px}
+
+/* ---------- Buttons ---------- */
+.btn{padding:.5rem 1rem;border:none;border-radius:.5rem;background:var(--accent);color:#fff;
+font-size:.9rem;cursor:pointer;display:inline-flex;align-items:center;gap:.5rem}
+.btn:hover{opacity:.9}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+.btn-sm{padding:.35rem .75rem;font-size:.8rem}
+.btn-secondary{background:var(--border)}
+.btn-success{background:var(--green)}
+.btn-danger{background:var(--red)}
+
+/* ---------- Status indicators ---------- */
+.status-badge{display:inline-flex;align-items:center;gap:.4rem;padding:.25rem .6rem;
+border-radius:.25rem;font-size:.8rem;font-weight:600}
+.status-badge.ready{background:rgba(34,197,94,.15);color:var(--green)}
+.status-badge.not-ready{background:rgba(239,68,68,.15);color:var(--red)}
+
+/* ---------- Answer box ---------- */
+.answer-box{background:var(--bg);border:1px solid var(--border);border-radius:.5rem;
+padding:1rem;margin:1rem 0;min-height:80px}
+.answer-box .answer-text{white-space:pre-wrap;line-height:1.6}
+.answer-box .placeholder{color:var(--muted);font-style:italic}
+
+/* ---------- Sources table ---------- */
+.sources-table{width:100%;border-collapse:collapse;font-size:.85rem;margin-top:1rem}
+.sources-table th,.sources-table td{text-align:left;padding:.5rem .75rem;
+border-bottom:1px solid var(--border)}
+.sources-table th{color:var(--muted);font-size:.75rem;text-transform:uppercase}
+
+/* ---------- File list ---------- */
+.file-list{display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem}
+.file-item{padding:.4rem .75rem;border:1px solid var(--border);border-radius:.35rem;
+background:var(--bg);font-size:.85rem;cursor:pointer;transition:.2s}
+.file-item:hover{border-color:var(--accent);color:var(--accent)}
+.file-item.active{background:var(--accent);color:#fff;border-color:var(--accent)}
+.file-item .ext{color:var(--muted);font-size:.75rem;margin-left:.3rem}
+.file-item[data-ext="py"]{display:none}
+
+/* ---------- Feedback bar ---------- */
+.feedback-bar{display:flex;gap:.75rem;margin-top:1rem;padding-top:1rem;
+border-top:1px solid var(--border)}
+.feedback-bar .btn{flex:1;justify-content:center}
+
+/* ---------- Output panel ---------- */
+.output-panel{background:var(--bg);border:1px solid var(--border);border-radius:.5rem;
+padding:1rem;margin-top:1rem;font-family:'Fira Code',monospace;font-size:.85rem;
+white-space:pre-wrap;max-height:300px;overflow-y:auto;display:none}
+.output-panel.visible{display:block}
+
+/* ---------- Status grid ---------- */
+.status-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem}
+.status-item{display:flex;justify-content:space-between;align-items:center;
+padding:.75rem;border:1px solid var(--border);border-radius:.5rem;background:var(--bg)}
+.status-item .key{color:var(--muted);font-size:.85rem}
+.status-item .value{font-weight:600}
+</style>
+</head>
+<body>
+
+<!-- ============= Login overlay ============= -->
+<div id="login-overlay">
+  <div id="login-box">
+    <h2>Operator Console</h2>
+    <p id="login-error"></p>
+    <input id="token-input" type="password" placeholder="Admin token" autofocus />
+    <button onclick="doLogin()">Sign In</button>
+  </div>
+</div>
+
+<!-- ============= Dashboard ============= -->
+<div id="app" style="display:none">
+<header>
+  <h1>Operator Console — Ask → Fix → Rebuild → Test → Publish</h1>
+  <div style="display:flex;gap:1rem;align-items:center">
+    <a href="/admin" style="font-size:.85rem">Admin Dashboard →</a>
+    <span class="logout" onclick="doLogout()">Sign out</span>
+  </div>
+</header>
+
+<div class="container">
+
+<!-- Publish Status (top) -->
+<div class="section" style="background:rgba(108,99,255,.05)">
+  <h2><span class="icon">📊</span> Publish Status</h2>
+  <div class="cards" id="status-cards">
+    <div class="card">
+      <div class="label">Status</div>
+      <div class="value" id="s-status">—</div>
+    </div>
+    <div class="card">
+      <div class="label">Config Version</div>
+      <div class="value" id="s-version">—</div>
+    </div>
+    <div class="card">
+      <div class="label">Index Count</div>
+      <div class="value" id="s-indexes">—</div>
+    </div>
+    <div class="card">
+      <div class="label">Last Eval</div>
+      <div class="value" id="s-eval">—</div>
+    </div>
+  </div>
+  <div style="display:flex;gap:1rem;margin-top:1rem">
+    <button class="btn" onclick="refreshStatus()">🔄 Refresh Status</button>
+    <span id="status-time" style="color:var(--muted);font-size:.85rem"></span>
+  </div>
+</div>
+
+<!-- Ask AI -->
+<div class="section">
+  <h2><span class="icon">💬</span> Ask AI</h2>
+  <div class="form-row">
+    <div class="form-group" style="flex:2">
+      <label>Question</label>
+      <input id="ask-input" type="text" placeholder="Enter a question to test the RAG system..." />
+    </div>
+    <div class="form-group" style="flex:0;display:flex;align-items:flex-end">
+      <button class="btn" id="ask-btn" onclick="doAsk()">Ask</button>
+    </div>
+  </div>
+
+  <div class="answer-box" id="answer-box" style="display:none">
+    <div class="answer-text" id="answer-text"></div>
+  </div>
+
+  <table class="sources-table" id="sources-table" style="display:none">
+    <thead><tr><th>Source</th><th>Type</th><th>Score</th></tr></thead>
+    <tbody id="sources-body"></tbody>
+  </table>
+
+  <div id="ask-meta" style="margin-top:1rem;font-size:.85rem;color:var(--muted)"></div>
+
+  <div class="feedback-bar" id="feedback-bar" style="display:none">
+    <button class="btn btn-success" onclick="askFeedback('good')">✓ Good</button>
+    <button class="btn btn-danger" onclick="askFeedback('wrong')">✗ Wrong Answer</button>
+    <button class="btn btn-secondary" onclick="askFeedback('edit')">✎ Edit Knowledge</button>
+  </div>
+</div>
+
+<!-- Knowledge Manager -->
+<div class="section">
+  <h2><span class="icon">📁</span> Knowledge Manager</h2>
+  <div style="display:flex;gap:1rem;margin-bottom:1rem;flex-wrap:wrap">
+    <div class="form-group" style="flex:1;min-width:200px">
+      <label>New File Name</label>
+      <input id="new-filename" type="text" placeholder="e.g., pricing_updates.md" />
+    </div>
+    <div style="display:flex;align-items:flex-end;padding-bottom:.35rem">
+      <button class="btn" onclick="createNewFile()">+ Create New</button>
+    </div>
+  </div>
+
+  <div class="file-list" id="file-list"><span style="color:var(--muted)">Loading files...</span></div>
+
+  <div class="form-group">
+    <label>Current File: <span id="current-file" style="color:var(--accent);font-weight:600">—</span></label>
+    <textarea id="file-editor" placeholder="Select a file to edit..."></textarea>
+  </div>
+
+  <div style="display:flex;gap:1rem">
+    <button class="btn btn-success" id="save-file-btn" onclick="saveFile()" disabled>💾 Save File</button>
+    <span id="save-status" style="color:var(--muted);font-size:.85rem"></span>
+  </div>
+</div>
+
+<!-- Rebuild Knowledge -->
+<div class="section">
+  <h2><span class="icon">🔨</span> Rebuild Knowledge</h2>
+  <p style="color:var(--muted);font-size:.85rem;margin-bottom:1rem">
+    Rebuilds FAISS indexes from files in data/raw. This may take 1-5 minutes depending on corpus size.
+  </p>
+  <div style="display:flex;gap:1rem;align-items:center">
+    <button class="btn" id="rebuild-btn" onclick="doRebuild()">🔨 Rebuild Indexes</button>
+    <span id="rebuild-status" style="color:var(--muted);font-size:.85rem"></span>
+  </div>
+  <div class="output-panel" id="rebuild-output"></div>
+</div>
+
+<!-- Run Tests -->
+<div class="section">
+  <h2><span class="icon">🧪</span> Run Tests</h2>
+  <p style="color:var(--muted);font-size:.85rem;margin-bottom:1rem">
+    Run evaluation suite against saved test cases. Requires scripts/run_eval.py to be configured.
+  </p>
+  <div style="display:flex;gap:1rem;align-items:center">
+    <button class="btn" id="eval-btn" onclick="doEval()">▶ Run Evaluation</button>
+    <span id="eval-status" style="color:var(--muted);font-size:.85rem"></span>
+  </div>
+  <div class="output-panel" id="eval-output"></div>
+</div>
+
+</div><!-- .container -->
+</div><!-- #app -->
+
+<script>
+/* ================================================================
+   Auth & State
+   ================================================================ */
+const _urlToken = new URLSearchParams(window.location.search).get('token') || '';
+let TOKEN = _urlToken || sessionStorage.getItem('admin_token') || '';
+if(_urlToken) sessionStorage.setItem('admin_token', _urlToken);
+const API = window.location.origin;
+let currentFile = '';
+let lastAskQuery = '';
+let lastAskResult = null;
+
+function headers(){
+  return {'X-Admin-Token': TOKEN, 'Content-Type': 'application/json'};
+}
+
+async function doLogin(){
+  const input = document.getElementById('token-input');
+  const err = document.getElementById('login-error');
+  const t = input.value.trim();
+  if(!t){err.textContent='Token required';return}
+  try{
+    const r = await fetch(API+'/admin/status',{headers:{'X-Admin-Token':t}});
+    if(!r.ok) throw new Error('Invalid token');
+    TOKEN = t;
+    sessionStorage.setItem('admin_token',t);
+    document.getElementById('login-overlay').style.display='none';
+    document.getElementById('app').style.display='block';
+    initConsole();
+  }catch(e){err.textContent=e.message}
+}
+
+function doLogout(){
+  TOKEN='';sessionStorage.removeItem('admin_token');
+  document.getElementById('app').style.display='none';
+  document.getElementById('login-overlay').style.display='flex';
+  document.getElementById('token-input').value='';
+}
+
+(async function(){
+  if(!TOKEN) return;
+  try{
+    const r = await fetch(API+'/admin/status',{headers:{'X-Admin-Token':TOKEN}});
+    if(r.ok){
+      document.getElementById('login-overlay').style.display='none';
+      document.getElementById('app').style.display='block';
+      initConsole();
+    }else{sessionStorage.removeItem('admin_token');TOKEN=''}
+  }catch(_){sessionStorage.removeItem('admin_token');TOKEN=''}
+})();
+
+/* ================================================================
+   Init
+   ================================================================ */
+function initConsole(){
+  refreshStatus();
+  loadFiles();
+}
+
+/* ================================================================
+   Status
+   ================================================================ */
+async function refreshStatus(){
+  try{
+    const r = await fetch(API+'/admin/status',{headers:headers()});
+    if(r.status===401){doLogout();return}
+    const s = await r.json();
+
+    const statusEl = document.getElementById('s-status');
+    statusEl.textContent = s.ready ? 'READY' : 'NOT READY';
+    statusEl.className = 'value ' + (s.ready ? 'ok' : 'bad');
+
+    document.getElementById('s-version').textContent = s.config_version || '—';
+    document.getElementById('s-indexes').textContent = s.index_count || 0;
+
+    const evalText = s.last_eval_pass_rate !== null
+      ? (s.last_eval_pass_rate + '% pass')
+      : 'Not run';
+    document.getElementById('s-eval').textContent = evalText;
+
+    document.getElementById('status-time').textContent = 'Updated ' + new Date().toLocaleTimeString();
+  }catch(e){console.error('refreshStatus',e)}
+}
+
+/* ================================================================
+   Ask AI
+   ================================================================ */
+async function doAsk(){
+  const input = document.getElementById('ask-input');
+  const btn = document.getElementById('ask-btn');
+  const q = input.value.trim();
+  if(!q) return;
+
+  btn.disabled=true; btn.textContent='Asking...';
+  lastAskQuery = q;
+
+  try{
+    const r = await fetch(API+'/admin/ask',{
+      method:'POST',headers:headers(),body:JSON.stringify({question:q})
+    });
+    if(r.status===401){doLogout();return}
+
+    const d = await r.json();
+    lastAskResult = d;
+
+    // Show answer
+    const answerBox = document.getElementById('answer-box');
+    const answerText = document.getElementById('answer-text');
+    answerBox.style.display='block';
+    answerText.textContent = d.answer || '(no answer)';
+
+    // Show sources
+    const sourcesTable = document.getElementById('sources-table');
+    const sourcesBody = document.getElementById('sources-body');
+    if(d.sources && d.sources.length){
+      sourcesTable.style.display='table';
+      sourcesBody.innerHTML = d.sources.map(s=>`<tr>
+        <td>${esc(s.source||s.doc||'—')}</td>
+        <td>${esc(s.doc_type||'—')}</td>
+        <td>${s.score!=null?Number(s.score).toFixed(4):'—'}</td>
+      </tr>`).join('');
+    }else{
+      sourcesTable.style.display='none';
+    }
+
+    // Meta
+    const metaParts = [];
+    metaParts.push(`Latency: ${d.latency_ms||0}ms`);
+    metaParts.push(`Intent: ${d.intent||'—'} (${(d.intent_confidence||0).toFixed(2)})`);
+    if(d.failure_type) metaParts.push(`Failure: ${d.failure_type}`);
+    metaParts.push(`Grounded: ${d.grounded?'Yes':'No'}`);
+    document.getElementById('ask-meta').textContent = metaParts.join(' | ');
+
+    // Show feedback
+    document.getElementById('feedback-bar').style.display='flex';
+
+  }catch(e){
+    document.getElementById('answer-text').textContent = 'Error: '+e.message;
+    document.getElementById('answer-box').style.display='block';
+  }finally{
+    btn.disabled=false; btn.textContent='Ask';
+  }
+}
+
+function askFeedback(type){
+  if(type==='edit'){
+    // Focus knowledge manager
+    document.getElementById('file-editor').scrollIntoView({behavior:'smooth'});
+    return;
+  }
+  alert(`Feedback recorded: ${type}\nQuery: ${lastAskQuery.slice(0,50)}...`);
+}
+
+/* ================================================================
+   Knowledge Manager
+   ================================================================ */
+async function loadFiles(){
+  try{
+    const r = await fetch(API+'/admin/knowledge',{headers:headers()});
+    if(r.status===401){doLogout();return}
+    const d = await r.json();
+
+    const list = document.getElementById('file-list');
+    if(!d.files || !d.files.length){
+      list.innerHTML = '<span style="color:var(--muted)">No files in data/raw</span>';
+      return;
+    }
+
+    list.innerHTML = d.files.map(f=>{
+      const ext = f.name.split('.').pop();
+      return `<div class="file-item" data-file="${esc(f.name)}" onclick="openFile('${esc(f.name)}')">
+        ${esc(f.name)}<span class="ext">.${esc(ext)}</span>
+      </div>`;
+    }).join('');
+  }catch(e){console.error('loadFiles',e)}
+}
+
+async function openFile(filename){
+  currentFile = filename;
+  document.getElementById('current-file').textContent = filename;
+  document.getElementById('save-file-btn').disabled = true;
+  document.getElementById('save-status').textContent = 'Loading...';
+
+  // Update active state
+  document.querySelectorAll('.file-item').forEach(el=>{
+    el.classList.toggle('active', el.dataset.file===filename);
+  });
+
+  try{
+    const r = await fetch(API+'/admin/knowledge/'+encodeURIComponent(filename),{headers:headers()});
+    if(r.status===401){doLogout();return}
+    const d = await r.json();
+
+    document.getElementById('file-editor').value = d.content || '';
+    document.getElementById('save-file-btn').disabled = false;
+    document.getElementById('save-status').textContent = `${d.size||0} bytes`;
+  }catch(e){
+    document.getElementById('save-status').textContent = 'Error: '+e.message;
+  }
+}
+
+async function saveFile(){
+  if(!currentFile) return;
+
+  const btn = document.getElementById('save-file-btn');
+  const content = document.getElementById('file-editor').value;
+
+  btn.disabled=true;
+  document.getElementById('save-status').textContent = 'Saving...';
+
+  try{
+    const r = await fetch(API+'/admin/knowledge/'+encodeURIComponent(currentFile),{
+      method:'POST',headers:headers(),body:JSON.stringify({content})
+    });
+    if(r.status===401){doLogout();return}
+
+    const d = await r.json();
+    if(d.status==='ok'){
+      document.getElementById('save-status').textContent = `Saved! (${d.size||0} bytes)`;
+      setTimeout(()=>{document.getElementById('save-status').textContent=''},2000);
+    }else{
+      throw new Error('Save failed');
+    }
+  }catch(e){
+    document.getElementById('save-status').textContent = 'Error: '+e.message;
+  }finally{
+    btn.disabled=false;
+  }
+}
+
+async function createNewFile(){
+  const input = document.getElementById('new-filename');
+  const name = input.value.trim();
+  if(!name) return;
+
+  // Ensure extension
+  const filename = name.includes('.') ? name : name + '.md';
+
+  try{
+    // Create empty file
+    const r = await fetch(API+'/admin/knowledge/'+encodeURIComponent(filename),{
+      method:'POST',headers:headers(),body:JSON.stringify({content:''})
+    });
+    if(r.status===401){doLogout();return}
+
+    const d = await r.json();
+    if(d.status==='ok'){
+      input.value = '';
+      loadFiles();
+      openFile(filename);
+    }
+  }catch(e){console.error('createNewFile',e)}
+}
+
+/* ================================================================
+   Rebuild
+   ================================================================ */
+async function doRebuild(){
+  const btn = document.getElementById('rebuild-btn');
+  const status = document.getElementById('rebuild-status');
+  const output = document.getElementById('rebuild-output');
+
+  btn.disabled=true;
+  status.textContent='Running... (this may take 1-5 minutes)';
+  output.textContent='';
+  output.classList.remove('visible');
+
+  try{
+    const r = await fetch(API+'/admin/rebuild',{method:'POST',headers:headers()});
+    if(r.status===401){doLogout();return}
+
+    const d = await r.json();
+    output.textContent = d.output || (d.error ? 'Error: '+d.error : 'No output');
+    output.classList.add('visible');
+
+    status.textContent = d.success ? '✓ Complete' : '✗ Failed';
+    status.style.color = d.success ? 'var(--green)' : 'var(--red)';
+
+    // Refresh status after rebuild
+    setTimeout(refreshStatus, 1000);
+  }catch(e){
+    status.textContent='Error: '+e.message;
+    status.style.color='var(--red)';
+  }finally{
+    btn.disabled=false;
+  }
+}
+
+/* ================================================================
+   Eval
+   ================================================================ */
+async function doEval(){
+  const btn = document.getElementById('eval-btn');
+  const status = document.getElementById('eval-status');
+  const output = document.getElementById('eval-output');
+
+  btn.disabled=true;
+  status.textContent='Running...';
+  output.textContent='';
+  output.classList.remove('visible');
+
+  try{
+    const r = await fetch(API+'/admin/eval',{method:'POST',headers:headers()});
+    if(r.status===401){doLogout();return}
+
+    const d = await r.json();
+
+    if(d.status==='not_configured'){
+      output.textContent = 'Evaluation not configured.\n\nCreate scripts/run_eval.py to enable.';
+      status.textContent = 'Not configured';
+    }else if(d.status==='ok'){
+      output.textContent = `Passed: ${d.pass||0}
+Failed: ${d.fail||0}
+Wrong source: ${d.wrong_source||0}
+False refusal: ${d.false_refusal||0}`;
+      status.textContent = `Pass rate: ${Math.round((d.pass||0)/((d.pass||0)+(d.fail||0)||1)*100)}%`;
+      status.style.color = d.fail ? 'var(--yellow)' : 'var(--green)';
+    }else{
+      output.textContent = d.output || d.error || 'Failed';
+      status.textContent = 'Failed';
+      status.style.color = 'var(--red)';
+    }
+    output.classList.add('visible');
+  }catch(e){
+    status.textContent='Error: '+e.message;
+    status.style.color='var(--red)';
+  }finally{
+    btn.disabled=false;
+  }
+}
+
+/* ================================================================
+   Helpers
+   ================================================================ */
+function esc(s){
+  if(!s) return '';
+  const d=document.createElement('div');d.textContent=s;return d.innerHTML;
+}
+
+/* Enter key handlers */
+document.getElementById('token-input').addEventListener('keydown',function(e){if(e.key==='Enter')doLogin()});
+document.getElementById('ask-input').addEventListener('keydown',function(e){if(e.key==='Enter')doAsk()});
+document.getElementById('new-filename').addEventListener('keydown',function(e){if(e.key==='Enter')createNewFile()});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Implements Issue #34.

Adds the Operator Console workflow:

```text
Ask → Fix Knowledge → Rebuild → Test → Publish
```

Scope:
- UI + thin admin API layer only
- no retrieval/generation/routing/threshold/reranker changes
- knowledge editing restricted to `.md` and `.txt`
- path traversal blocked
- all API endpoints require `X-Admin-Token`
- Windows compatible via `filelock`

Validation:
- `python -m py_compile api/server/main.py api/server/admin_routes.py`
- local server starts
- `/admin/operator` loads
- Ask AI works
- Knowledge Manager lists/opens/saves `.md`/`.txt`
- `.py` editing blocked
- rebuild returns status
- eval returns result or `not_configured`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/binz2008-star/rag-engine/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
